### PR TITLE
[ Feat ] 배포 자동화 설정 

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,0 +1,33 @@
+name: deploy to vercel
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: Ivoryeee
+          destination-repository-name: Morib-Landing
+          user-email: ${{ secrets.DEPLOY_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+          
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./Morib-Landing/* ./output
+cp -R ./output ./Morib-Landing/


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #4

## ✅ 작업 리스트

- [x] 빌드 파일 작성
- [x] deploy 스크립트 작성

## 🔧 작업 내용

vercel로 Morib-Landing 페이지를 배포해 두었습니다. 
무료 플랜을 사용하기 위해서는 기존 레포를 개인 레포에 fork 해야 하고, 기존 레포에서 변경사항이 생겼을 경우 수동으로 다시 fork를 해야 한다는 번거로움이 있습니다. 따라서, build.sh와 push-deploy.yml 파일을 작성해 배포 자동화를 설정했습니다. 

## 🧐 새로 알게된 점
vercel 무료 플랜을 사용하기 위해서는 개인 레포에 fork하는 방식을 사용해야 함

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
